### PR TITLE
Phase 3: Income routing rewrite

### DIFF
--- a/src/Monivise.API/Controllers/SimulatorController.cs
+++ b/src/Monivise.API/Controllers/SimulatorController.cs
@@ -20,14 +20,16 @@ namespace Monivise.API.Controllers
         private readonly IBucketRepository _buckets;
         private readonly ITransactionRepository _transactions;
         private readonly IFinancialCalculationService _calc;
+        private readonly IWantCategoryRepository _wantCategories;
 
         public SimulatorController(IBudgetCycleRepository cycles, IBucketRepository buckets,
-            ITransactionRepository transactions, IFinancialCalculationService calc)
+            ITransactionRepository transactions, IFinancialCalculationService calc, IWantCategoryRepository wantCategories)
         {
             _cycles = cycles;
             _buckets = buckets;
             _transactions = transactions;
             _calc = calc;
+            _wantCategories = wantCategories;
         }
 
         private Guid UserId => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -43,7 +45,10 @@ namespace Monivise.API.Controllers
             var buckets = (await _buckets.GetActiveByUserIdAsync(UserId, ct)).ToList();
             var txns = (await _transactions.GetByUserAndCycleAsync(UserId, cycle.Id, ct)).ToList();
 
-            var result = _calc.SimulateDecision(dto.BucketId, dto.IntakeItemId, dto.WantCategoryId, dto.Amount, buckets, txns, cycle);
+            WantCategory? wantCategory = dto.WantCategoryId is not null
+                    ? await _wantCategories.GetByIdAsync(dto.WantCategoryId.Value, ct)
+                    : null;
+            var result = _calc.SimulateDecision(dto.BucketId, dto.IntakeItemId, wantCategory, dto.Amount, buckets, txns, cycle);
 
             return Ok(new DecisionSimulationResponseDto
             {
@@ -76,7 +81,10 @@ namespace Monivise.API.Controllers
                 CanAfford = result.CanAfford,
                 WillDrawFromBuffer = result.WillDrawFromBuffer,
                 BufferDrawAmount = result.BufferDrawAmount,
-                BufferBalanceAfter = result.BufferBalanceAfter
+                BufferBalanceAfter = result.BufferBalanceAfter,
+                WillDrawFromPool = result.WillDrawFromPool,
+                PoolBalanceAfter = result.PoolBalanceAfter,
+                PoolDrawAmount = result.PoolDrawAmount
             });
         }
 
@@ -92,12 +100,19 @@ namespace Monivise.API.Controllers
                 ?? throw new BucketNotFoundException(dto.BucketId);
             if (bucket.UserId != UserId) return Forbid();
 
+            WantCategory? wantCategory = dto.WantCategoryId is not null
+                    ? await _wantCategories.GetByIdAsync(dto.WantCategoryId.Value, ct)
+                    : null;
+
             var buckets = (await _buckets.GetActiveByUserIdAsync(UserId, ct)).ToList();
             var txns = (await _transactions.GetByUserAndCycleAsync(UserId, cycle.Id, ct)).ToList();
-            var preCheck = _calc.SimulateDecision(dto.BucketId, dto.IntakeItemId, dto.WantCategoryId, dto.Amount, buckets, txns, cycle);
+            var preCheck = _calc.SimulateDecision(dto.BucketId, dto.IntakeItemId, wantCategory, dto.Amount, buckets, txns, cycle);
 
             if (!preCheck.CanAfford)
                 return UnprocessableEntity(new { code = "CANNOT_AFFORD", detail = "Even the buffer can't cover this." });
+
+            if (preCheck.WillDrawFromPool)
+                cycle.DrawFromUnpricedPool(preCheck.PoolDrawAmount);
 
             if (preCheck.WillDrawFromBuffer)
                 cycle.DrawFromBuffer(preCheck.BufferDrawAmount);

--- a/src/Monivise.API/Controllers/TransactionsController.cs
+++ b/src/Monivise.API/Controllers/TransactionsController.cs
@@ -20,15 +20,19 @@ namespace Monivise.API.Controllers
         private readonly ITransactionRepository _transactions;
         private readonly IFinancialCalculationService _calc;
         private readonly IAuditLogRepository _audit;
+        private readonly IIntakeProfileRepository _intakes;
+        private readonly IGoalRepository _goals;
 
         public TransactionsController(IBudgetCycleRepository cycles, IBucketRepository buckets,
-            ITransactionRepository transactions, IFinancialCalculationService calc, IAuditLogRepository audit)
+            ITransactionRepository transactions, IFinancialCalculationService calc, IAuditLogRepository audit, IIntakeProfileRepository intakes, IGoalRepository goals)
         {
             _cycles = cycles;
             _buckets = buckets;
             _transactions = transactions;
             _calc = calc;
             _audit = audit;
+            _intakes = intakes;
+            _goals = goals;
         }
 
         private Guid UserId => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -40,20 +44,29 @@ namespace Monivise.API.Controllers
             var cycle = await _cycles.GetActiveByUserIdAsync(UserId, ct)
                 ?? throw new CycleNotFoundException(UserId);
 
+            if (dto.IncomeType == "Primary")
+                return await HandlePrimaryIncome(cycle, ct);
+
+            return await HandleExtraIncome(dto, cycle, ct);
+        }
+
+        private async Task<IActionResult> HandlePrimaryIncome(BudgetCycle cycle, CancellationToken ct)
+        {
+            var profile = await _intakes.GetByUserIdAsync(UserId, ct)
+                ?? throw new ArgumentException("No intake profile — complete onboarding first.");
+
+            decimal amount = profile.BaselineMonthlyIncome;
+            if (amount <= 0) return UnprocessableEntity(new { code = "NO_BASELINE_INCOME" });
+
             var buckets = (await _buckets.GetActiveByUserIdAsync(UserId, ct)).ToList();
-            var incomeType = Enum.Parse<Monivise.Domain.Enums.IncomeType>(dto.IncomeType);
-            var splits = dto.IncomeType == "Extra"
-                ? _calc.AllocateIncome(dto.Amount, buckets.Where(b => b.Type == BucketType.Investment)).ToList()
-                : _calc.AllocateIncome(dto.Amount, buckets).ToList();
+            var splits = _calc.AllocateIncome(amount, buckets).ToList();
 
             var txns = splits.Select(s => Transaction.CreateIncome(
-                 UserId, s.BucketId, cycle.Id, s.Amount, dto.Source, incomeType)).ToList();
+                UserId, s.BucketId, cycle.Id, s.Amount, "Salary", IncomeType.Primary)).ToList();
 
             await _transactions.AddRangeAsync(txns, ct);
-
-            var logPayload = System.Text.Json.JsonSerializer.Serialize(new { dto.Amount, dto.Source });
+            var logPayload = System.Text.Json.JsonSerializer.Serialize(new { Amount = amount, Source = "Salary" });
             await _audit.AddAsync(AuditLog.Create(UserId, "ADD_INCOME", "Transaction", null, logPayload), ct);
-
             await _transactions.SaveChangesAsync(ct);
             await _audit.SaveChangesAsync(ct);
 
@@ -67,12 +80,86 @@ namespace Monivise.API.Controllers
                     BucketColor = buckets.First(b => b.Id == t.BucketId).Color,
                     Kind = "Income",
                     Amount = t.Amount,
-                    Source = dto.Source,
-                    IncomeType = dto.IncomeType,
+                    Source = "Salary",
+                    IncomeType = "Primary",
                     Date = t.Date
                 }).ToList();
 
             return CreatedAtAction(nameof(AddIncome), responseDtos);
+        }
+
+        private async Task<IActionResult> HandleExtraIncome(AddIncomeDto dto, BudgetCycle cycle, CancellationToken ct)
+        {
+            if (dto.Amount is not > 0)
+                return BadRequest(new { code = "AMOUNT_REQUIRED" });
+            if (dto.Splits is null || dto.Splits.Count == 0)
+                return BadRequest(new { code = "SPLITS_REQUIRED" });
+
+            var validDestinations = new[] { "Buffer", "Wants", "Goal" };
+            if (dto.Splits.Any(s => !validDestinations.Contains(s.Destination)))
+                return BadRequest(new { code = "INVALID_DESTINATION", detail = "Destination must be Buffer, Wants, or Goal." });
+
+            decimal totalPct = dto.Splits.Sum(s => s.Percent);
+            if (Math.Abs(totalPct - 100m) > 0.01m)
+                return BadRequest(new { code = "SPLITS_MUST_SUM_TO_100", totalPct });
+
+            Goal? activeGoal = null;
+            if (dto.Splits.Any(s => s.Destination == "Goal"))
+            {
+                activeGoal = await _goals.GetActiveAsync(UserId, ct);
+                if (activeGoal is null)
+                    return UnprocessableEntity(new { code = "NO_ACTIVE_GOAL", detail = "You selected Goal but have no active goal to contribute to." });
+            }
+
+            decimal amount = dto.Amount.Value;
+            decimal remainder = amount;
+            var applied = new List<(string Destination, decimal Amount)>();
+
+            for (int i = 0; i < dto.Splits.Count; i++)
+            {
+                bool isLast = i == dto.Splits.Count - 1;
+                decimal share = isLast ? remainder : Math.Round(amount * dto.Splits[i].Percent / 100m, 2);
+                remainder -= share;
+                if (share <= 0) continue;
+
+                switch (dto.Splits[i].Destination)
+                {
+                    case "Buffer":
+                        cycle.AddToBuffer(share);
+                        break;
+                    case "Wants":
+                        cycle.AddToUnpricedPool(share);
+                        break;
+                    case "Goal":
+                        activeGoal!.Contribute(share);
+                        break;
+                }
+                applied.Add((dto.Splits[i].Destination, share));
+            }
+
+            await _cycles.SaveChangesAsync(ct);
+            if (activeGoal is not null) await _goals.SaveChangesAsync(ct);
+
+            var logPayload = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                Amount = amount,
+                Source = dto.Source ?? "Extra",
+                Splits = applied.Select(a => new { a.Destination, a.Amount })
+            });
+            await _audit.AddAsync(AuditLog.Create(UserId, "ADD_INCOME_EXTRA", "BudgetCycle", cycle.Id, logPayload), ct);
+            await _audit.SaveChangesAsync(ct);
+
+            // Buffer/Wants-pool/Goal aren't Buckets, so there's no Bucket-linked Transaction
+            // to create here — same pattern SurplusSweepService already uses for goal
+            // contributions. This means these entries won't show in Dashboard "Recent
+            // activity" (which reads Bucket-linked Transactions only) — known, acceptable
+            // gap; Buffer/pool top-ups surface via their own dedicated balances instead.
+            return Ok(new
+            {
+                message = "Extra income applied",
+                amount,
+                applied = applied.Select(a => new { destination = a.Destination, amount = a.Amount })
+            });
         }
 
         [HttpPost("expense")]

--- a/src/Monivise.Application/DTOs/Dashboard/DecisionSimulationResponseDto.cs
+++ b/src/Monivise.Application/DTOs/Dashboard/DecisionSimulationResponseDto.cs
@@ -9,8 +9,11 @@ namespace Monivise.Application.DTOs.Dashboard
     {
         public string BucketName { get; set; } = string.Empty;
         public bool WillDrawFromBuffer { get; set; } 
+        public bool WillDrawFromPool { get; set; }
         public decimal BufferDrawAmount { get; set; }
         public decimal BufferBalanceAfter { get; set; }
+        public decimal PoolDrawAmount { get; set; }
+        public decimal PoolBalanceAfter { get; set; }
         public decimal Amount { get; set; }
         public decimal BucketBalanceBefore { get; set; }
         public decimal BucketBalanceAfter { get; set; }

--- a/src/Monivise.Application/DTOs/Dashboard/DecisionSimulationResult.cs
+++ b/src/Monivise.Application/DTOs/Dashboard/DecisionSimulationResult.cs
@@ -19,6 +19,9 @@ namespace Monivise.Application.DTOs.Dashboard
         public decimal DailyLimitBefore { get; init; }
         public decimal DailyLimitAfter { get; init; }
         public decimal DepletionPercent { get; init; }
+        public bool WillDrawFromPool { get; init; }
+        public decimal PoolBalanceAfter { get; init; }
+        public decimal PoolDrawAmount { get; init; }
         public RiskLevel Risk { get; init; }
         public List<string> RegretSignals { get; init; } = [];
         public bool WillOverdraftBucket { get; init; }

--- a/src/Monivise.Application/DTOs/Transactions/AddIncomeDto.cs
+++ b/src/Monivise.Application/DTOs/Transactions/AddIncomeDto.cs
@@ -7,13 +7,12 @@ namespace Monivise.Application.DTOs.Transactions
 {
     public class AddIncomeDto
     {
-        [Required, Range(1, 9_999_999)]
-        public decimal Amount { get; set; }
-
-        [Required, RegularExpression("^(Salary|Freelance|Gift|Business|Other)$")]
-        public string Source { get; set; } = "Salary";
+        [Range(1, 9_999_999)]
+        public decimal? Amount { get; set; }
+        public string? Source { get; set; }
 
         [RegularExpression("^(Primary|Extra)$")]
         public string IncomeType { get; set; } = "Primary";
+        public List<IncomeAllocationSplitDto>? Splits { get; set; }
     }
 }

--- a/src/Monivise.Application/DTOs/Transactions/IncomeAllocationSplitDto.cs
+++ b/src/Monivise.Application/DTOs/Transactions/IncomeAllocationSplitDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Monivise.Application.DTOs.Transactions
+{
+    public class IncomeAllocationSplitDto
+    {
+        public string Destination { get; set; } = string.Empty; // Buffer|Wants|Goal
+        public decimal Percent { get; set; }
+    }
+}

--- a/src/Monivise.Application/Interfaces/Services/IFinancialCalculationService.cs
+++ b/src/Monivise.Application/Interfaces/Services/IFinancialCalculationService.cs
@@ -16,7 +16,7 @@ namespace Monivise.Application.Interfaces.Services
         decimal GetSpendingPace(IEnumerable<Bucket> buckets, IEnumerable<Transaction> txns, BudgetCycle cycle);
         decimal GetDailyLimit(decimal safeToSpend, decimal pace, BudgetCycle cycle);
         IEnumerable<AllocationPreview> AllocateIncome(decimal amount, IEnumerable<Bucket> activeBuckets);
-        DecisionSimulationResult SimulateDecision(Guid bucketId, Guid? intakeItemId, Guid? wantCategoryId,
+        DecisionSimulationResult SimulateDecision(Guid bucketId, Guid? intakeItemId, WantCategory? wantCategory,
     decimal amount, IEnumerable<Bucket> buckets, IEnumerable<Transaction> txns, BudgetCycle cycle);
         RiskLevel GetRiskLevel(decimal postSafeToSpend, decimal postDailyLimit,
             decimal avgDailyBudget, decimal depletionPercent);

--- a/src/Monivise.Application/Services/FinancialCalculationService.cs
+++ b/src/Monivise.Application/Services/FinancialCalculationService.cs
@@ -118,7 +118,7 @@ namespace Monivise.Application.Services
 
         // ─── DECISION SIMULATION ───
 
-        public DecisionSimulationResult SimulateDecision(Guid bucketId, Guid? intakeItemId, Guid? wantCategoryId,
+        public DecisionSimulationResult SimulateDecision(Guid bucketId, Guid? intakeItemId, WantCategory? wantCategory,
     decimal amount, IEnumerable<Bucket> buckets, IEnumerable<Transaction> txns, BudgetCycle cycle)
         {
             var txnList = txns.ToList();
@@ -134,20 +134,44 @@ namespace Monivise.Application.Services
 
             // ── Item-level check, when the caller targets a specific item ──
             bool willDrawFromBuffer = false;
+            bool willDrawFromPool = false;
             decimal bufferDrawAmount = 0m;
+            decimal poolDrawAmount = 0m;
             decimal bufferBalanceAfter = cycle.BufferBalance;
+            decimal poolBalanceAfter = cycle.UnpricedWantsPoolBalance;
 
-            if (intakeItemId is not null || wantCategoryId is not null)
+            if (wantCategory is not null && wantCategory.IsUnpriced)
+            {
+                if (amount > cycle.UnpricedWantsPoolBalance)
+                {
+                    // Pool alone can't cover it — the shortfall falls to Buffer.
+                    decimal poolPortion = Math.Max(0, cycle.UnpricedWantsPoolBalance);
+                    decimal bufferPortion = amount - poolPortion;
+                    willDrawFromPool = poolPortion > 0;
+                    poolDrawAmount = poolPortion;
+                    poolBalanceAfter = cycle.UnpricedWantsPoolBalance - poolPortion;
+                    willDrawFromBuffer = true;
+                    bufferDrawAmount = bufferPortion;
+                    bufferBalanceAfter = cycle.BufferBalance - bufferPortion;
+                }
+                else
+                {
+                    willDrawFromPool = true;
+                    poolDrawAmount = amount;
+                    poolBalanceAfter = cycle.UnpricedWantsPoolBalance - amount;
+                }
+            }
+            else if (intakeItemId is not null || (wantCategory is not null && !wantCategory.IsUnpriced))
             {
                 decimal itemAllocated = txnList
                     .Where(t => t.Kind == TransactionKind.Income
                         && ((intakeItemId is not null && t.IntakeItemId == intakeItemId)
-                            || (wantCategoryId is not null && t.WantCategoryId == wantCategoryId)))
+                            || (wantCategory is not null && t.WantCategoryId == wantCategory.Id)))
                     .Sum(t => t.Amount);
                 decimal itemSpent = txnList
                     .Where(t => t.Kind == TransactionKind.Expense
                         && ((intakeItemId is not null && t.IntakeItemId == intakeItemId)
-                            || (wantCategoryId is not null && t.WantCategoryId == wantCategoryId)))
+                            || (wantCategory is not null && t.WantCategoryId == wantCategory.Id)))
                     .Sum(t => t.Amount);
                 decimal itemRemaining = itemAllocated - itemSpent;
 
@@ -156,7 +180,7 @@ namespace Monivise.Application.Services
                     decimal shortfall = amount - Math.Max(0, itemRemaining);
                     willDrawFromBuffer = true;
                     bufferDrawAmount = shortfall;
-                    bufferBalanceAfter = cycle.BufferBalance - shortfall; // may go negative — surfaced to caller, not clamped here
+                    bufferBalanceAfter = cycle.BufferBalance - shortfall;
                 }
             }
 
@@ -189,7 +213,9 @@ namespace Monivise.Application.Services
             if (cycle.RemainingDays <= 5 && safeToSpendAfter < dailyLimitBefore * 3)
                 regretSignals.Add($"Only {cycle.RemainingDays} days left — post-spend buffer is thin");
 
-            bool canAfford = willDrawFromBuffer ? bufferBalanceAfter >= 0 : bucketBalanceAfter >= 0;
+            bool canAfford = (willDrawFromPool ? poolBalanceAfter >= 0 : true)
+                    && (willDrawFromBuffer ? bufferBalanceAfter >= 0 : true)
+                    && (!willDrawFromBuffer && !willDrawFromPool ? bucketBalanceAfter >= 0 : true);
 
             return new DecisionSimulationResult
             {
@@ -206,10 +232,13 @@ namespace Monivise.Application.Services
                 RegretSignals = regretSignals,
                 WillOverdraftBucket = bucketBalanceAfter < 0,
                 WillDrawFromBuffer = willDrawFromBuffer,
+                WillDrawFromPool = willDrawFromPool,
                 BufferDrawAmount = bufferDrawAmount,
                 BufferBalanceAfter = bufferBalanceAfter,
                 CurrentBalance = bucketBalanceBefore,
                 PostSpendBalance = bucketBalanceAfter,
+                PoolDrawAmount = poolDrawAmount,
+                PoolBalanceAfter = poolBalanceAfter,
                 PaceScore = pace,
                 AverageDailySpend = avgDailyBudget,
                 DaysRemaining = cycle.RemainingDays,


### PR DESCRIPTION
## Phase 3: Income routing rewrite

### Summary
Primary income becomes backend-authoritative (no client-sent amount, ever). Extra income gets the user-chosen percentage split across Buffer/Wants(unpriced pool)/Goal from the prototype, fully validated server-side. Closes the unpriced-pool drawdown gap Phase 2 left open in the Simulator.

### What changed

**Income**
- `TransactionsController.AddIncome` split into `HandlePrimaryIncome`/`HandleExtraIncome`
- Primary: ignores any client-sent amount, pulls `IntakeProfile.BaselineMonthlyIncome` directly — closes a gap where a bad client could drift the "consistent salary" figure the model depends on
- Extra: validates destinations (`Buffer`/`Wants`/`Goal` only), percentages must sum to exactly 100, rejects `Goal` selection with no active goal (`NO_ACTIVE_GOAL`) instead of silently no-op'ing
- `AddIncomeDto.Amount` made properly optional (was `[Required]` on a nullable field, which would've 400'd every Primary call before the method body even ran — caught during review, not originally shipped this way)
- Buffer/Wants-pool/Goal top-ups don't create Bucket-linked `Transaction`s (same pattern as existing goal-contribution sweeps) — won't appear in Dashboard "Recent activity," known and acceptable

**Simulator**
- `SimulateDecision` now takes the `WantCategory` entity (not just its id) to check `.IsUnpriced` and route the affordability check correctly: unpriced categories check against `BudgetCycle.UnpricedWantsPoolBalance`, everything else checks item-level allocation with Buffer fallback
- `SimulatorController.Commit`: fixed to fetch the `WantCategory` entity before calling the service (was passing the raw `Guid?`, compile error), and fixed a duplicated Buffer-draw call that would have double-deducted on every buffer-drawing spend

### Testing
- `dotnet build` — clean

### Known follow-up
Test project not yet updated for the signature changes across Phases 1–3 (`BuildPathways`, `SimulateDecision`, `AddIncomeDto`, `BucketType`). Tracked separately, not blocking.

